### PR TITLE
Added Mozilla Readability for getting the text

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-redux": "^5.0.1",
+    "readability": "git://github.com/bwbroersma/readability.git#62045da",
     "redux": "^3.6.0",
     "redux-act": "^1.1.0",
     "redux-observable": "^0.12.2",

--- a/src/activitylogger/content_script/index.js
+++ b/src/activitylogger/content_script/index.js
@@ -1,10 +1,30 @@
 import { getMetadata, metadataRules } from 'page-metadata-parser'
+import { Readability } from 'readability'
 
 // Get the basic info and text content (for search index) of this page.
 function gatherPageInfo() {
     // Extract info from all sorts of meta tags (og, twitter, etc.)
     const visitedUrl = window.location.href
-    const text = document.body.innerText
+
+    const location = document.location
+    const uri = {
+        spec: location.href,
+        host: location.host,
+        prePath: location.protocol + "//" + location.host,
+        scheme: location.protocol.substr(0, location.protocol.indexOf(":")),
+        pathBase: location.protocol + "//" + location.host + location.pathname.substr(0, location.pathname.lastIndexOf("/") + 1)
+    };
+    const documentClone = document.cloneNode(true)
+    const article = new Readability(uri, documentClone).parse()
+    let text;
+    if (article) {
+        const articleDom = document.createElement('main')
+        articleDom.innerHTML = article.content
+        text = articleDom.innerText
+    } else {
+        text = document.body.innerText
+    }
+
     const pageMetadata = getMetadata(document, visitedUrl, metadataRules)
     return {
         ...pageMetadata,


### PR DESCRIPTION
Added Mozilla Readability for getting the text, some issues / notes:
* To use the [Readability](https://github.com/mozilla/readability/) package I needed to [add an export to it](https://github.com/bwbroersma/readability/commit/62045da0dc9d92daf556abdaefbf1ea661dcb03c), it would be wiser if you would reference to your own fork of Readability.
* Is setting the innerHTML of a DOM Element a security issue?

This would close https://github.com/WebMemex/memextension/issues/2.