### PR TITLE
[background] added events to ensure right page capture

### DIFF
--- a/src/util/event-to-promise.js
+++ b/src/util/event-to-promise.js
@@ -16,10 +16,10 @@ export default function eventToPromise({
     reject: rejectOpts,
 }) {
     // We can get a single options object, or an array of them, or undefined.
-    if (typeof resolveOpts !== 'Array') {
+    if (!Array.isArray(resolveOpts)) {
         resolveOpts = (resolveOpts !== undefined) ? [resolveOpts] : []
     }
-    if (typeof rejectOpts !== 'Array') {
+    if (!Array.isArray(rejectOpts)) {
         rejectOpts = (rejectOpts !== undefined) ? [rejectOpts] : []
     }
 


### PR DESCRIPTION
PR pertaining to #15 .
I have added event listeners to all tab watching events that ensure if the tab url changes , it will reject the promise such that the watching action can't continue