### PR TITLE
Avoid cross-folder relative imports

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -40,6 +40,7 @@ const files = [
 const browserifySettings = {
     debug: true,
     extensions: ['.jsx', '.css'],
+    paths: ['.'],
 }
 
 function createBundle({entries, output, destination, cssOutput},

--- a/src/activity-logger/background/log-page-visit.js
+++ b/src/activity-logger/background/log-page-visit.js
@@ -1,5 +1,5 @@
 import { generateVisitDocId, isWorthRemembering } from '..'
-import { reidentifyOrStorePage } from '../../page-storage/store-page'
+import { reidentifyOrStorePage } from 'src/page-storage/store-page'
 
 
 // Store the visit in PouchDB.

--- a/src/activity-logger/index.js
+++ b/src/activity-logger/index.js
@@ -1,7 +1,7 @@
 // Stuff that is to be accessible from other modules (folders)
 
 import docuri from 'docuri'
-import randomString from '../util/random-string'
+import randomString from 'src/util/random-string'
 
 export const visitKeyPrefix = 'visit/'
 

--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,5 @@
-import './activity-logger/background'
-import './omnibar'
+import 'src/activity-logger/background'
+import 'src/omnibar'
 
 
 function openOverview() {

--- a/src/browser-history/background/import-history.js
+++ b/src/browser-history/background/import-history.js
@@ -2,11 +2,11 @@
 // The browser's historyItems and visitItems are quite straightforwardly
 // converted to pageDocs and visitDocs (sorry for the confusingly similar name).
 
-import db from '../pouchdb'
-import { updatePageSearchIndex } from '../search/find-pages'
+import db from 'src/pouchdb'
+import { updatePageSearchIndex } from 'src/search/find-pages'
 import { isWorthRemembering, generateVisitDocId,
-         visitKeyPrefix, convertVisitDocId } from '../activity-logger'
-import { generatePageDocId } from '../page-storage'
+         visitKeyPrefix, convertVisitDocId } from 'src/activity-logger'
+import { generatePageDocId } from 'src/page-storage'
 
 
 // Get the historyItems (visited places/pages; not each visit to them)

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -1,2 +1,2 @@
-import './activity-logger/content_script'
-import './page-analysis/content_script'
+import 'src/activity-logger/content_script'
+import 'src/page-analysis/content_script'

--- a/src/omnibar.js
+++ b/src/omnibar.js
@@ -1,8 +1,8 @@
 import debounce from 'lodash/fp/debounce'
 import escapeHtml from 'lodash/fp/escape'
 
-import { filterVisitsByQuery } from './search'
-import niceTime from './util/nice-time'
+import { filterVisitsByQuery } from 'src/search'
+import niceTime from 'src/util/nice-time'
 
 
 const shortUrl = (url, maxLength=50) => {

--- a/src/overview/actions.js
+++ b/src/overview/actions.js
@@ -1,7 +1,7 @@
 import { createAction } from 'redux-act'
 
-import { onDatabaseChange } from '../pouchdb'
-import { filterVisitsByQuery } from '../search'
+import { onDatabaseChange } from 'src/pouchdb'
+import { filterVisitsByQuery } from 'src/search'
 import { ourState } from './selectors'
 
 

--- a/src/overview/components/ResultList.jsx
+++ b/src/overview/components/ResultList.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
-import { makeRangeTransform, makeNonlinearTransform } from '../../util/make-range-transform'
-import niceTime from '../../util/nice-time'
+import { makeRangeTransform, makeNonlinearTransform } from 'src/util/make-range-transform'
+import niceTime from 'src/util/nice-time'
 import VisitAsListItem from './VisitAsListItem'
 
 import styles from './ResultList.css'

--- a/src/overview/components/VisitAsListItem.js
+++ b/src/overview/components/VisitAsListItem.js
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 
 import styles from './VisitAsListItem.css'
 
-import {localVersionAvailable, LinkToLocalVersion } from '../../page-viewer'
+import {localVersionAvailable, LinkToLocalVersion } from 'src/page-viewer'
 
 const VisitAsListItem = ({doc, compact}) => {
     const visitClasses = classNames({

--- a/src/overview/main.jsx
+++ b/src/overview/main.jsx
@@ -3,14 +3,14 @@ import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
 
 import configureStore from './store'
-import overview from '../overview'
+import overview from 'src/overview'
 
 import './base.css'
 
 // Include development tools if we are not building for production
 let ReduxDevTools = undefined
 if (process.env.NODE_ENV !== 'production') {
-    ReduxDevTools = require('../dev/redux-devtools').default
+    ReduxDevTools = require('src/dev/redux-devtools').default
 }
 
 // Set up the Redux store

--- a/src/overview/store.js
+++ b/src/overview/store.js
@@ -4,7 +4,7 @@ import { createEpicMiddleware } from 'redux-observable';
 import { combineEpics } from 'redux-observable';
 import thunk from 'redux-thunk'
 
-import overview from '../overview'
+import overview from 'src/overview'
 
 const rootReducer = combineReducers({
     overview: overview.reducer,

--- a/src/page-analysis/background/get-fav-icon.js
+++ b/src/page-analysis/background/get-fav-icon.js
@@ -1,4 +1,4 @@
-import responseToDataURI from '../../util/response-to-data-uri'
+import responseToDataURI from 'src/util/response-to-data-uri'
 
 // Get a tab's fav-icon (website logo) as a data URI
 function getFavIcon({tabId}) {

--- a/src/page-analysis/background/index.js
+++ b/src/page-analysis/background/index.js
@@ -1,10 +1,10 @@
 import assocPath from 'lodash/fp/assocPath'
 
-import { whenPageDOMLoaded } from '../../util/tab-events'
-import { remoteFunction } from '../../util/webextensionRPC'
-import whenAllSettled from '../../util/when-all-settled'
-import db from '../../pouchdb'
-import { updatePageSearchIndex } from '../../search/find-pages'
+import { whenPageDOMLoaded } from 'src/util/tab-events'
+import { remoteFunction } from 'src/util/webextensionRPC'
+import whenAllSettled from 'src/util/when-all-settled'
+import db from 'src/pouchdb'
+import { updatePageSearchIndex } from 'src/search/find-pages'
 
 import { revisePageFields } from '..'
 import getFavIcon from './get-fav-icon'

--- a/src/page-analysis/background/make-screenshot.js
+++ b/src/page-analysis/background/make-screenshot.js
@@ -1,5 +1,5 @@
-import delay from '../../util/delay'
-import { whenPageLoadComplete, whenTabActive } from '../../util/tab-events'
+import delay from 'src/util/delay'
+import { whenPageLoadComplete, whenTabActive } from 'src/util/tab-events'
 
 // Take a screenshot of the tabId, if it is active.
 // Returns a promise of the screenshot (a png image in a data URI).

--- a/src/page-analysis/content_script/index.js
+++ b/src/page-analysis/content_script/index.js
@@ -1,4 +1,4 @@
-import { makeRemotelyCallable } from '../../util/webextensionRPC'
+import { makeRemotelyCallable } from 'src/util/webextensionRPC'
 
 import extractPageText from './extract-page-text'
 import extractPageMetadata from './extract-page-metadata'

--- a/src/page-storage/deduplication.js
+++ b/src/page-storage/deduplication.js
@@ -2,8 +2,8 @@
 
 import maxBy from 'lodash/fp/maxBy'
 
-import db from '../pouchdb'
-import { getTimestamp } from '../activity-logger'
+import db from 'src/pouchdb'
+import { getTimestamp } from 'src/activity-logger'
 import determinePageSameness, { Sameness } from './sameness'
 
 function samenessLinkType({sameness}) {

--- a/src/page-storage/index.js
+++ b/src/page-storage/index.js
@@ -1,5 +1,5 @@
 import docuri from 'docuri'
-import randomString from '../util/random-string'
+import randomString from 'src/util/random-string'
 
 export const pageKeyPrefix = 'page/'
 

--- a/src/page-storage/store-page.js
+++ b/src/page-storage/store-page.js
@@ -1,5 +1,5 @@
-import { findPagesByUrl } from '../search/find-pages'
-import analysePage from '../page-analysis/background'
+import { findPagesByUrl } from 'src/search/find-pages'
+import analysePage from 'src/page-analysis/background'
 import tryDedupePage from './deduplication'
 import { generatePageDocId } from '.'
 

--- a/src/search/find-pages.js
+++ b/src/search/find-pages.js
@@ -1,9 +1,9 @@
 import get from 'lodash/fp/get'
 import update from 'lodash/fp/update'
 
-import db, { normaliseFindResult, resultRowsById } from '../pouchdb'
-import { pageKeyPrefix } from '../activity-logger'
-import { searchableTextFields, revisePageFields } from '../page-analysis'
+import db, { normaliseFindResult, resultRowsById } from 'src/pouchdb'
+import { pageKeyPrefix } from 'src/activity-logger'
+import { searchableTextFields, revisePageFields } from 'src/page-analysis'
 
 
 // Resolve redirects from (deduplicated) pages, replacing them in the results.

--- a/src/search/find-visits.js
+++ b/src/search/find-visits.js
@@ -4,8 +4,8 @@ import reverse from 'lodash/fp/reverse'
 import unionBy from 'lodash/unionBy' // the fp version does not support >2 inputs (lodash issue #3025)
 import sortBy from 'lodash/fp/sortBy'
 
-import db, { normaliseFindResult, resultRowsById }  from '../pouchdb'
-import { convertVisitDocId, visitKeyPrefix, getTimestamp } from '../activity-logger'
+import db, { normaliseFindResult, resultRowsById }  from 'src/pouchdb'
+import { convertVisitDocId, visitKeyPrefix, getTimestamp } from 'src/activity-logger'
 import { getPages } from './find-pages'
 
 


### PR DESCRIPTION
Use the `src` folder as a phony npm module to avoid `../../..` imports.
Relative imports within a subdirectory of `src` are left as is.

There seem to be [many hacky approaches](https://gist.github.com/branneman/8048520) to work around this ugly issue. I'm following [slorber's approach](http://stackoverflow.com/questions/20158401/how-do-i-manage-relative-path-aliasing-in-multiple-grunt-browserify-bundles/23608416#23608416) of using browserify's `paths` option. I decided to keep the `src` prefix to each folder in order to make clear they are not external modules.
Thanks @AlexMarvelo for the suggestion.