### PR TITLE
Add Linter for CSS (fix #85)

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,1 @@
+extension/

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,6 @@
+{
+  "extends": "stylelint-config-standard",
+  "rules":{
+    "indentation": 4
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "watch": "gulp watch",
     "fx-run": "web-ext -s extension run",
     "fx-build": "npm run build-prod && web-ext -s extension -a dist/firefox build",
-    "lint": "eslint --ext js,jsx .",
+    "lint": "eslint --ext js,jsx . && stylelint '**/*.css'",
     "lint-fix": "eslint --ext js,jsx --fix ."
   },
   "dependencies": {
@@ -65,6 +65,8 @@
     "redux-devtools": "^3.3.1",
     "redux-devtools-dock-monitor": "^1.1.1",
     "redux-devtools-log-monitor": "^1.2.0",
+    "stylelint": "^7.10.1",
+    "stylelint-config-standard": "^16.0.0",
     "uglifyify": "^3.0.4",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",

--- a/src/options/base.css
+++ b/src/options/base.css
@@ -2,7 +2,8 @@
     box-sizing: border-box;
 }
 
-html, body {
+html,
+body {
     margin: 0;
     font-size: 18px;
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;

--- a/src/overview/components/DateRangeSelection.css
+++ b/src/overview/components/DateRangeSelection.css
@@ -5,9 +5,11 @@
     margin: auto;
     width: 20em;
 }
+
 .dateRangeSelection > * {
     flex: 1 50%;
 }
+
 .datePicker {
     width: 100%;
     min-width: 100px;
@@ -15,6 +17,7 @@
     border-radius: 2px;
     box-shadow: 1px 2px 2px #888;
     padding: 4px;
+
     &:focus {
         outline: none;
         border: 1px solid grey;

--- a/src/overview/components/LoadingIndicator.css
+++ b/src/overview/components/LoadingIndicator.css
@@ -6,7 +6,7 @@
     margin: 20px auto;
 }
 
-.dot{
+.dot {
     position: absolute;
     display: inline-block;
     height: 10px;
@@ -38,9 +38,11 @@
     0% {
         bottom: 10%;
     }
+
     50% {
         bottom: 90%;
     }
+
     100% {
         bottom: 10%;
     }

--- a/src/overview/components/ResultList.css
+++ b/src/overview/components/ResultList.css
@@ -36,6 +36,7 @@
     0% {
         opacity: 0;
     }
+
     100% {
         opacity: 1;
     }

--- a/src/overview/components/VisitAsListItem.css
+++ b/src/overview/components/VisitAsListItem.css
@@ -21,6 +21,7 @@
         border: 1px solid black;
         box-shadow: 3px 4px 3px #888;
     }
+
     transition: border 200ms, box-shadow 200ms;
 
     &:focus {
@@ -37,11 +38,11 @@
     transform-origin: top;
     margin-bottom: -20px;
 
-    &:hover, &:focus {
+    &:hover,
+    &:focus {
         opacity: 1;
     }
 }
-
 
 .screenshotContainer {
     flex-shrink: 0;
@@ -66,7 +67,7 @@
 
 .descriptionContainer {
     flex: 1 1 auto;
-    padding: 10px 0px 10px 10px;
+    padding: 10px 0 10px 10px;
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -109,14 +110,16 @@
     & img {
         margin: 5px 8px;
         width: 15px;
-
         opacity: 0.1;
+
         @nest .root:hover & {
             opacity: 0.4;
+
             &:hover {
                 opacity: 1;
             }
         }
+
         transition: opacity 200ms;
     }
 }


### PR DESCRIPTION
[Refs](https://github.com/WebMemex/webmemex-extension/issues/85). Added a CSS linter for the repository using [stylelint](https://stylelint.io). Currently it runs with the same command as the eslint but we can change it. There were only minor changes needed to be made to the css of the project as it was pretty much in line with the standard config provided by stylelint. For more info on the [standard-config-stylelint](https://github.com/stylelint/stylelint-config-standard).
There is one persisting error that I cannot resolve as I think it should be resolved by the maintainer. Please tell me any more rules are needed to be added.
*NOTE* Also there is no autofix in this particular linter.

edit: Sorry I couldn't integrate this with the eslint PR and had to sent a separate one. I was planning to do so but I took a lot of time it seems.
