### PR TITLE
Add ESLint watch (fix #72)

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -7,6 +7,7 @@ import browserify from 'browserify'
 import watchify from 'watchify'
 import babelify from 'babelify'
 import envify from 'loose-envify/custom'
+import eslint from 'gulp-eslint'
 import uglifyify from 'uglifyify'
 import path from 'path'
 import cssModulesify from 'css-modulesify'
@@ -99,16 +100,35 @@ gulp.task('copyStaticFiles', () => {
     }
 })
 
-gulp.task('build-prod', ['copyStaticFiles'], () => {
+gulp.task('lint', () => {
+    return gulp.src(['**/*.js', '**/*.jsx'])
+        .pipe(eslint())
+        .pipe(eslint.format())
+        .pipe(eslint.results(results => {
+            console.log(`Total Errors: ${results.errorCount}`)
+        }))
+})
+
+gulp.task('build-prod', ['copyStaticFiles', 'lint'], () => {
     sourceFiles.forEach(bundle => createBundle(bundle, {watch: false, production: true}))
 })
 
-gulp.task('build', ['copyStaticFiles'], () => {
+gulp.task('build', ['copyStaticFiles', 'lint'], () => {
     sourceFiles.forEach(bundle => createBundle(bundle, {watch: false}))
 })
 
-gulp.task('watch', ['copyStaticFiles'], () => {
+gulp.task('build-watch', ['copyStaticFiles'], () => {
     sourceFiles.forEach(bundle => createBundle(bundle, {watch: true}))
 })
 
+gulp.task('lint-watch', () => {
+    gulp.watch(['**/*.js', '**/*.jsx'])
+    .on('change', (file) => {
+        return gulp.src(file.path)
+        .pipe(eslint())
+        .pipe(eslint.format())
+    })
+})
+
+gulp.task('watch', ['lint', 'build-watch', 'lint-watch'])
 gulp.task('default', ['watch'])

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -12,6 +12,7 @@ import uglifyify from 'uglifyify'
 import path from 'path'
 import cssModulesify from 'css-modulesify'
 import cssnext from 'postcss-cssnext'
+import runSequence from 'run-sequence'
 
 
 const staticFiles = {
@@ -130,5 +131,7 @@ gulp.task('lint-watch', () => {
     })
 })
 
-gulp.task('watch', ['lint', 'build-watch', 'lint-watch'])
+gulp.task('watch', function() {
+    runSequence('lint', 'build-watch', 'lint-watch')
+})
 gulp.task('default', ['watch'])

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "redux-devtools": "^3.3.1",
     "redux-devtools-dock-monitor": "^1.1.1",
     "redux-devtools-log-monitor": "^1.2.0",
+    "run-sequence": "^1.2.2",
     "stylelint": "^7.10.1",
     "stylelint-config-standard": "^16.0.0",
     "uglifyify": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "eslint-plugin-react": "^6.10.3",
     "eslint-plugin-standard": "^2.1.1",
     "gulp": "^3.9.1",
+    "gulp-eslint": "^3.0.1",
     "gulp-identity": "^0.1.0",
     "gulp-uglify": "^2.0.1",
     "loose-envify": "^1.3.0",


### PR DESCRIPTION
[Refs](https://github.com/WebMemex/webmemex-extension/issues/72)
DO NOT MERGE YET:
I would like to resolve all the sub tasks on the issue list for this issue in this PR itself. I still need to run the linter in build and test. I was thinking of simply cascading the eslint command with the gulp watch and the test. Any advice @Treora ?

Here I have added a gulp task called lint-watch which lints the files. Also I have changed the name of watch to build-watch and added another gulp task called watch which basically combine both lint-watch and build-watch. This will help us implement the watch over every file and lint it as soon as any change takes place.

**NOTE**: For some reason there is a lot of delay in running the lint. On my machine I was constantly getting a minute or 50s to lint all the files after the change takes place, and theses were when I waited after every changes. Its worse for consecutive changes taking place very quickly.

EDIT: Good to see Travis in action. :)