### PR TITLE
Support deleting visits/pages (fix #21)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "pouchdb-browser": "^6.1.0",
     "pouchdb-find": "^0.10.4",
     "pouchdb-quick-search": "^1.2.0",
-    "pouchdb-upsert": "^2.0.2",
     "prop-types": "^15.5.10",
     "react": "^15.4.1",
     "react-datepicker": "^0.43.0",

--- a/src/overview/actions.js
+++ b/src/overview/actions.js
@@ -2,6 +2,8 @@ import { createAction } from 'redux-act'
 
 import { onDatabaseChange } from 'src/pouchdb'
 import { filterVisitsByQuery } from 'src/search'
+import { deleteVisitAndPage } from 'src/page-storage/deletion'
+
 import { ourState } from './selectors'
 
 
@@ -13,6 +15,7 @@ export const showLoadingIndicator = createAction('overview/showLoadingIndicator'
 export const hideLoadingIndicator = createAction('overview/hideLoadingIndicator')
 export const setStartDate = createAction('overview/setStartDate')
 export const setEndDate = createAction('overview/setEndDate')
+export const hideVisit = createAction('overview/hideVisit')
 
 
 // == Actions that trigger other actions ==
@@ -25,6 +28,15 @@ export function init() {
 
         // Track database changes, to e.g. trigger search result refresh
         onDatabaseChange(change => dispatch(handlePouchChange({change})))
+    }
+}
+
+export function deleteVisit({visitId}) {
+    return async function (dispatch, getState) {
+        // Hide the visit directly (optimistically).
+        dispatch(hideVisit({visitId}))
+        // Remove it from the database.
+        await deleteVisitAndPage({visitId})
     }
 }
 

--- a/src/overview/components/VisitAsListItem.css
+++ b/src/overview/components/VisitAsListItem.css
@@ -106,20 +106,28 @@
     color: inherit;
     text-decoration: none;
     padding-top: 5px;
+}
+
+.button {
+    display: inline;
+    border: none;
+    background-color: transparent;
+    padding: 0;
+    opacity: 0.1;
+
+    @nest .root:hover & {
+        opacity: 0.4;
+
+        &:hover {
+            opacity: 1;
+            cursor: pointer;
+        }
+    }
+
+    transition: opacity 200ms;
 
     & img {
         margin: 5px 8px;
         width: 15px;
-        opacity: 0.1;
-
-        @nest .root:hover & {
-            opacity: 0.4;
-
-            &:hover {
-                opacity: 1;
-            }
-        }
-
-        transition: opacity 200ms;
     }
 }

--- a/src/overview/components/VisitAsListItem.jsx
+++ b/src/overview/components/VisitAsListItem.jsx
@@ -59,15 +59,19 @@ const VisitAsListItem = ({doc, compact, onTrashButtonClick}) => {
                 <div className={styles.time}>{niceTime(doc.visitStart)}</div>
             </div>
             <div className={styles.buttonsContainer}>
-                <a
+                <button
+                    className={styles.button}
                     onClick={e => { e.preventDefault(); onTrashButtonClick() }}
-                    title="Forget this item"
+                    title='Forget this item'
                 >
                     <img src='img/trash-icon.png' alt='🗑 forget' />
-                </a>
+                </button>
                 {localVersionAvailable({page: doc.page})
                     ? (
-                        <LinkToLocalVersion page={doc.page}>
+                        <LinkToLocalVersion
+                            className={styles.button}
+                            page={doc.page}
+                        >
                             <img src='img/save-icon.png' alt='💾 saved' />
                         </LinkToLocalVersion>
                     )

--- a/src/overview/components/VisitAsListItem.jsx
+++ b/src/overview/components/VisitAsListItem.jsx
@@ -59,8 +59,11 @@ const VisitAsListItem = ({doc, compact, onTrashButtonClick}) => {
                 <div className={styles.time}>{niceTime(doc.visitStart)}</div>
             </div>
             <div className={styles.buttonsContainer}>
-                <a onClick={e => { e.preventDefault(); onTrashButtonClick() }}>
-                    <img src='img/trash-icon.png' alt='🗑 remove' />
+                <a
+                    onClick={e => { e.preventDefault(); onTrashButtonClick() }}
+                    title="Forget this item"
+                >
+                    <img src='img/trash-icon.png' alt='🗑 forget' />
                 </a>
                 {localVersionAvailable({page: doc.page})
                     ? (

--- a/src/overview/components/VisitAsListItem.jsx
+++ b/src/overview/components/VisitAsListItem.jsx
@@ -1,14 +1,17 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
 import classNames from 'classnames'
 
-import {localVersionAvailable, LinkToLocalVersion} from 'src/page-viewer'
+import { localVersionAvailable, LinkToLocalVersion } from 'src/page-viewer'
 import niceTime from 'src/util/nice-time'
+
 import ImgFromPouch from './ImgFromPouch'
 import styles from './VisitAsListItem.css'
+import { deleteVisit } from '../actions'
 
 
-const VisitAsListItem = ({doc, compact}) => {
+const VisitAsListItem = ({doc, compact, onTrashButtonClick}) => {
     const visitClasses = classNames({
         [styles.root]: true,
         [styles.compact]: compact,
@@ -56,7 +59,9 @@ const VisitAsListItem = ({doc, compact}) => {
                 <div className={styles.time}>{niceTime(doc.visitStart)}</div>
             </div>
             <div className={styles.buttonsContainer}>
-                <img src='img/trash-icon.png' alt='🗑 remove' />
+                <a onClick={e => { e.preventDefault(); onTrashButtonClick() }}>
+                    <img src='img/trash-icon.png' alt='🗑 remove' />
+                </a>
                 {localVersionAvailable({page: doc.page})
                     ? (
                         <LinkToLocalVersion page={doc.page}>
@@ -73,6 +78,14 @@ const VisitAsListItem = ({doc, compact}) => {
 VisitAsListItem.propTypes = {
     doc: PropTypes.object.isRequired,
     compact: PropTypes.bool,
+    onTrashButtonClick: PropTypes.func,
 }
 
-export default VisitAsListItem
+
+const mapStateToProps = state => ({})
+
+const mapDispatchToProps = (dispatch, {doc}) => ({
+    onTrashButtonClick: () => dispatch(deleteVisit({visitId: doc._id})),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(VisitAsListItem)

--- a/src/overview/reducer.js
+++ b/src/overview/reducer.js
@@ -1,6 +1,9 @@
+import update from 'lodash/fp/update'
+import remove from 'lodash/fp/remove'
 import { createReducer } from 'redux-act'
 
 import * as actions from './actions'
+
 
 const defaultState = {
     searchResult: {rows: []},
@@ -37,6 +40,12 @@ function hideLoadingIndicator(state) {
     return {...state, waitingForResults: state.waitingForResults - 1}
 }
 
+function hideVisit(state, {visitId}) {
+    return update('searchResult.rows',
+        rows => remove(row => row.id === visitId)(rows)
+    )(state)
+}
+
 export default createReducer({
     [actions.setQuery]: setQuery,
     [actions.setStartDate]: setStartDate,
@@ -44,4 +53,5 @@ export default createReducer({
     [actions.setSearchResult]: setSearchResult,
     [actions.showLoadingIndicator]: showLoadingIndicator,
     [actions.hideLoadingIndicator]: hideLoadingIndicator,
+    [actions.hideVisit]: hideVisit,
 }, defaultState)

--- a/src/page-storage/deduplication.js
+++ b/src/page-storage/deduplication.js
@@ -19,22 +19,26 @@ function samenessLinkType({sameness}) {
     return types[sameness]
 }
 
-function forgetPageContents({page}) {
+async function forgetPageContents({page}) {
     // Remove analysed bulky stuff
-    return db.upsert(page._id, doc => ({
+    const doc = await db.get(page._id)
+    const updatedDoc = {
         ...doc,
         extractedText: undefined,
         extractedMetadata: undefined,
         screenshot: undefined,
         favIcon: undefined,
-    }))
+    }
+    await db.put(updatedDoc)
 }
 
 async function addLink({targetId, sourceId, linkType}) {
-    await db.upsert(sourceId, doc => ({
+    const doc = await db.get(sourceId)
+    const updatedDoc = {
         ...doc,
         [linkType]: {_id: targetId},
-    }))
+    }
+    await db.put(updatedDoc)
 }
 
 async function replaceWithRedirect({oldPage, newPage, sameness}) {

--- a/src/page-storage/deletion.js
+++ b/src/page-storage/deletion.js
@@ -1,7 +1,6 @@
 import db from 'src/pouchdb'
 import { findVisits } from 'src/search/find-visits'
-import { getEquivalentPages } from 'src/search/find-pages'
-
+import { getEquivalentPages, updatePageSearchIndex } from 'src/search/find-pages'
 
 export async function deleteVisitAndPage({visitId}) {
     // Delete the visit object
@@ -31,5 +30,6 @@ async function deletePageIfOrphaned({pageId}) {
                 _deleted: true,
             })
         ))
+        await updatePageSearchIndex()
     }
 }

--- a/src/page-storage/deletion.js
+++ b/src/page-storage/deletion.js
@@ -1,0 +1,35 @@
+import db from 'src/pouchdb'
+import { findVisits } from 'src/search/find-visits'
+import { getEquivalentPages } from 'src/search/find-pages'
+
+
+export async function deleteVisitAndPage({visitId}) {
+    // Delete the visit object
+    const visit = await db.get(visitId)
+    const pageId = visit.page._id
+    await db.remove(visit)
+
+    // If this was the only visit linking to the page, also remove the page.
+    // (a simple choice for now; this behaviour may be changed in the future)
+    await deletePageIfOrphaned({pageId})
+}
+
+async function deletePageIfOrphaned({pageId}) {
+    // Because of deduplication, different page objects may redirect to this
+    // one, or this one may redirect to others. So we check for visits either
+    // referring to this page object or to any equivalent ones.
+    const pagesResult = await getEquivalentPages({pageId})
+    const visitsResult = await findVisits({pagesResult})
+    // If there are no visits to any of them, delete all these page objects.
+    // (otherwise, we leave them; it does not seem worth the effort to smartly
+    // prune some orphans among them already)
+    if (visitsResult.rows.length === 0) {
+        await db.bulkDocs(pagesResult.rows.map(
+            row => ({
+                _id: row.id,
+                _rev: row.value.rev,
+                _deleted: true,
+            })
+        ))
+    }
+}

--- a/src/pouchdb.js
+++ b/src/pouchdb.js
@@ -1,13 +1,11 @@
 import fromPairs from 'lodash/fp/fromPairs'
-
 import PouchDB from 'pouchdb-browser'
 import PouchDBQuickSearch from 'pouchdb-quick-search'
 import PouchDBFind from 'pouchdb-find'
-import PouchDBUpsert from 'pouchdb-upsert'
+
 
 PouchDB.plugin(PouchDBQuickSearch)
 PouchDB.plugin(PouchDBFind)
-PouchDB.plugin(PouchDBUpsert)
 
 const db = new PouchDB({
     name: 'webmemex',

--- a/src/util/tree-walker.js
+++ b/src/util/tree-walker.js
@@ -1,0 +1,29 @@
+// Generic tree walking algorithms
+
+// Given a node, return all nodes connected to it.
+export const getAllNodes = ({getParent, getChildren}) => async node => {
+    // First find the root, then crawl down each branch.
+    let root = await getRoot({getParent})(node)
+    const crawled = []
+    const toCrawl = [root]
+    let next
+    while ((next = toCrawl.pop()) !== undefined) {
+        if (crawled.includes(next) || toCrawl.includes(next)) {
+            continue
+        }
+        const children = await getChildren(next)
+        toCrawl.push(...children)
+        crawled.push(next)
+    }
+    return crawled
+}
+
+// Get the root (uppermost parent) of the tree of the given node.
+export const getRoot = ({getParent}) => async node => {
+    let root = node
+    let next
+    while ((next = await getParent(root)) !== undefined) {
+        root = next
+    }
+    return root
+}


### PR DESCRIPTION
Clicking the trash bin button now deletes that specific visit. It also
deletes the page object the visits refers to; unless there is still another
visit referring to it, or to an 'equivalent page': i.e. a page redirecting
(possibly indirectly) to the same page through a 'seeInstead' link.

Fixes #21.