### PR TITLE
Replace usual search with a simple word filter.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "pdfjs-dist": "^1.8.177",
     "pouchdb-browser": "^6.1.0",
     "pouchdb-find": "^0.10.4",
-    "pouchdb-quick-search": "^1.2.0",
     "prop-types": "^15.5.10",
     "react": "^15.4.1",
     "react-datepicker": "^0.43.0",

--- a/src/browser-history/background/import-history.js
+++ b/src/browser-history/background/import-history.js
@@ -3,7 +3,6 @@
 // converted to pageDocs and visitDocs (sorry for the confusingly similar name).
 
 import db from 'src/pouchdb'
-import { updatePageSearchIndex } from 'src/search/find-pages'
 import { isWorthRemembering, generateVisitDocId,
          visitKeyPrefix, convertVisitDocId } from 'src/activity-logger'
 import { generatePageDocId } from 'src/page-storage'
@@ -130,9 +129,6 @@ export default async function importHistory({
     // rejected, because their id (timestamp & history id) already exists.
     await db.bulkDocs(allDocs)
     console.timeEnd('import history')
-    console.time('rebuild search index')
-    await updatePageSearchIndex()
-    console.timeEnd('rebuild search index')
 }
 
 // Get the timestamp of the oldest visit in our database

--- a/src/page-analysis/background/index.js
+++ b/src/page-analysis/background/index.js
@@ -7,7 +7,6 @@ import whenAllSettled from 'src/util/when-all-settled'
 import delay from 'src/util/delay'
 import db from 'src/pouchdb'
 import updateDoc from 'src/util/pouchdb-update-doc'
-import { updatePageSearchIndex } from 'src/search/find-pages'
 
 import { revisePageFields } from '..'
 import getFavIcon from './get-fav-icon'
@@ -76,7 +75,6 @@ async function performPageAnalysis({pageId, tabId}) {
         storePageContent,
         storePageFreezeDried(),
     ])
-    await updatePageSearchIndex()
 }
 
 export default async function analysePage({page, tabId}) {

--- a/src/page-storage/deletion.js
+++ b/src/page-storage/deletion.js
@@ -1,6 +1,6 @@
 import db from 'src/pouchdb'
 import { findVisits } from 'src/search/find-visits'
-import { getEquivalentPages, updatePageSearchIndex } from 'src/search/find-pages'
+import { getEquivalentPages } from 'src/search/find-pages'
 
 export async function deleteVisitAndPage({visitId}) {
     // Delete the visit object
@@ -30,6 +30,5 @@ async function deletePageIfOrphaned({pageId}) {
                 _deleted: true,
             })
         ))
-        await updatePageSearchIndex()
     }
 }

--- a/src/pouchdb.js
+++ b/src/pouchdb.js
@@ -1,10 +1,8 @@
 import fromPairs from 'lodash/fp/fromPairs'
 import PouchDB from 'pouchdb-browser'
-import PouchDBQuickSearch from 'pouchdb-quick-search'
 import PouchDBFind from 'pouchdb-find'
 
 
-PouchDB.plugin(PouchDBQuickSearch)
 PouchDB.plugin(PouchDBFind)
 
 const db = new PouchDB({

--- a/src/search/find-pages.js
+++ b/src/search/find-pages.js
@@ -3,7 +3,7 @@ import update from 'lodash/fp/update'
 
 import db, { normaliseFindResult, resultRowsById } from 'src/pouchdb'
 import { pageKeyPrefix } from 'src/page-storage'
-import { searchableTextFields, revisePageFields } from 'src/page-analysis'
+import { revisePageFields } from 'src/page-analysis'
 import { getAllNodes } from 'src/util/tree-walker'
 
 
@@ -55,12 +55,6 @@ async function postprocessPagesResult({pagesResult, followRedirects}) {
     return pagesResult
 }
 
-const pageSearchIndexParams = {
-    filter: doc => (typeof doc._id === 'string'
-                    && doc._id.startsWith(pageKeyPrefix)),
-    fields: searchableTextFields,
-}
-
 // Get all pages for a given array of page ids
 export async function getPages({pageIds, ...otherOptions}) {
     let pagesResult = await db.allDocs({
@@ -69,31 +63,6 @@ export async function getPages({pageIds, ...otherOptions}) {
     })
     pagesResult = await postprocessPagesResult({...otherOptions, pagesResult})
     return pagesResult
-}
-
-// Search the log for pages matching given query (keyword) string
-export async function searchPages({
-    query,
-    limit,
-    ...otherOptions
-}) {
-    let pagesResult = await db.search({
-        ...pageSearchIndexParams,
-        query,
-        limit,
-        include_docs: true,
-        stale: 'update_after',
-    })
-    pagesResult = await postprocessPagesResult({...otherOptions, pagesResult})
-    return pagesResult
-}
-
-export async function updatePageSearchIndex() {
-    // Add new documents to the search index.
-    await db.search({
-        ...pageSearchIndexParams,
-        build: true,
-    })
 }
 
 export async function findPagesByUrl({url, ...otherOptions}) {

--- a/src/search/find-visits.js
+++ b/src/search/find-visits.js
@@ -40,7 +40,7 @@ async function insertPagesIntoVisits({
 // time (descending).
 // If pagesResult is given, only find visits to those pages.
 // XXX: If pages are redirected, only visits to the source page are found.
-export async function findVisits({startDate, endDate, limit, pagesResult}) {
+export async function findVisits({startDate, endDate, limit, pagesResult, skipUntil}) {
     let selector = {
         // Constrain by id (like with startkey/endkey), both to get only the
         // visit docs, and (if needed) to filter the visits after/before a
@@ -54,6 +54,7 @@ export async function findVisits({startDate, endDate, limit, pagesResult}) {
             $lte: endDate !== undefined
                 ? convertVisitDocId({timestamp: endDate})
                 : `${visitKeyPrefix}\uffff`,
+            $lt: skipUntil,
         },
     }
 

--- a/src/search/index.js
+++ b/src/search/index.js
@@ -1,5 +1,8 @@
+import get from 'lodash/fp/get'
+
+import { searchableTextFields } from 'src/page-analysis'
+
 import { findVisits, addVisitsContext } from './find-visits'
-import { searchPages } from './find-pages'
 
 
 // Search by keyword query, returning all docs if no query is given
@@ -11,22 +14,33 @@ export async function filterVisitsByQuery({
     includeContext = false,
 }) {
     if (query === '') {
-        return await findVisits({startDate, endDate, limit})
+        return findVisits({startDate, endDate, limit})
     } else {
-        const pagesResult = await searchPages({
-            query,
-            limit,
-            followRedirects: true,
-        })
-
-        let visitsResult = await findVisits({
-            pagesResult,
-            startDate,
-            endDate,
-        })
+        // Get all visits
+        let visitsResult = await findVisits({startDate, endDate})
+        // Filter for visits to pages that contain the query words.
+        visitsResult.rows = visitsResult.rows.filter(
+            row => pageMatchesQuery({page: row.doc.page, query})
+        )
+        // Apply the requested limit to the number of results.
+        visitsResult.rows = visitsResult.rows.slice(0, limit)
 
         if (includeContext) { visitsResult = await addVisitsContext({visitsResult}) }
 
         return visitsResult
     }
+}
+
+// We just use a simple literal word filter for now. No index, no ranking.
+function pageMatchesQuery({page, query}) {
+    // Get page text fields.
+    const texts = searchableTextFields.map(fieldName => get(fieldName)(page))
+        .filter(text => text) // remove undefined fields
+        .map(text => text.toLowerCase())
+
+    // Test if every word in the query is present in at least one text field.
+    const queryWords = query.toLowerCase().trim().split(/s+/)
+    return queryWords.every(word =>
+        texts.some(text => text.includes(word))
+    )
 }


### PR DESCRIPTION
pouchdb-quick-search was performing much too slow to be fun. Until we have
a faster alternative, we can use a quick rough hack: just filtering the
texts for presence of all query words. No indexing, stemming, tfidf, etc.

This takes time linear to the number of documents, but can easily be made
more efficient by limiting the number of visits we read, and loading more
of them when we need more results (= an infinite scroll solution). *(update: done)*

The idea was mentioned in https://github.com/WebMemex/webmemex-extension/issues/41#issuecomment-305907143