### PR TITLE
Edit pages

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -33,6 +33,8 @@ const staticFiles = {
     'node_modules/pdfjs-dist/build/pdf.worker.min.js': 'extension/lib',
     'node_modules/semantic-ui-css/semantic.min.css': 'extension/lib/semantic-ui',
     'node_modules/semantic-ui-css/themes/**/*': 'extension/lib/semantic-ui/themes',
+    'node_modules/medium-editor/dist/css/medium-editor.css': 'extension/lib/medium-editor',
+    'node_modules/medium-editor/dist/css/themes/default.css': 'extension/lib/medium-editor',
 }
 
 const sourceFiles = [

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "freeze-dry": "^0.1.0",
     "history": "^4.6.3",
     "lodash": "^4.17.4",
+    "medium-editor": "^5.23.0",
     "moment": "^2.18.1",
     "page-metadata-parser": "git+https://github.com/Treora/page-metadata-parser.git#npm-testable",
     "pdfjs-dist": "^1.8.492",

--- a/src/local-page/editor.js
+++ b/src/local-page/editor.js
@@ -1,0 +1,95 @@
+import MediumEditor from 'medium-editor'
+
+// Makes document.body editable using medium-editor. It applies some workarounds to, when reading
+// the document content, ignore the widgets and other stuff added by the editor itself.
+// XXX This is all very hacky. Some things should really be implemented inside medium-editor itself.
+export default function makeEditable(document) {
+    const stylesheets = [
+        '/lib/medium-editor/medium-editor.css',
+        '/lib/medium-editor/default.css',
+    ]
+    stylesheets.forEach(stylesheet => {
+        const href = browser.runtime.getURL(stylesheet)
+        const linkEl = document.createElement('link')
+        linkEl.setAttribute('rel', 'stylesheet')
+        linkEl.setAttribute('href', href)
+        linkEl.setAttribute('data-temporary-element', true)
+        document.head.insertAdjacentElement('beforeend', linkEl)
+    })
+
+    const editor = new MediumEditor(document.body, {
+        contentWindow: document.defaultView,
+        ownerDocument: document,
+        // toolbar: { // FIXME Toolbar appears at wrong position when scrolled down.
+        //     buttons: ['bold', 'italic'],
+        // },
+        toolbar: false,
+        anchorPreview: false,
+        extensions: {
+            'imageDragging': { // bogus extension to replace default
+                init: () => {},
+            },
+        },
+    })
+
+    // Return an object that behaves somewhat like MediumEditor's API.
+    return {
+        subscribe: editor.subscribe.bind(editor),
+        getContent: () => getContent(document),
+    }
+}
+
+function getContent(document) {
+    // Clone the document's root element into a new (invisible) document.
+    let shadowDoc = document.implementation.createHTMLDocument()
+    const rootElement = shadowDoc.importNode(
+        document.documentElement,
+        true /* deep copy */
+    )
+    shadowDoc.replaceChild(rootElement, shadowDoc.documentElement)
+
+    // Remove all elements created by us
+    const elements = Array.from(shadowDoc.querySelectorAll('*[data-temporary-element]'))
+    elements.forEach(element => {
+        element.parentNode.removeChild(element)
+    })
+
+    // Remove stuff added by medium-editor
+    removeMediumEditorStuff(shadowDoc)
+
+    const htmlString = shadowDoc.documentElement.outerHTML
+    return htmlString
+}
+
+// Hacky function to remove stuff inserted by medium-editor from the (cloned) DOM.
+function removeMediumEditorStuff(document) {
+    const editorElement = document.body
+
+    // Attributes removed by medium-editor's destroy function (https://github.com/yabwe/medium-editor/blob/4ba4fff23e38240407fd170c44e8486135d3f1f0/src/js/core.js#L732-L739)
+    editorElement.removeAttribute('contentEditable')
+    editorElement.removeAttribute('spellcheck')
+    editorElement.removeAttribute('data-medium-editor-body')
+    editorElement.classList.remove('medium-editor-body')
+    editorElement.removeAttribute('role')
+    editorElement.removeAttribute('aria-multiline')
+    editorElement.removeAttribute('medium-editor-index')
+    editorElement.removeAttribute('data-medium-editor-editor-index')
+
+    // Stuff destroyed by medium-editor extensions
+    editorElement.removeAttribute('data-placeholder')
+    const elementsToBeRemoved = Array.from(document.querySelectorAll([
+        '.medium-editor-toolbar-form',
+        '.medium-editor-toolbar',
+        '.medium-editor-anchor-preview',
+    ].join(', ')))
+    elementsToBeRemoved.forEach(el => {
+        try {
+            el.parentNode.removeChild(el)
+        } catch (err) {}
+    })
+
+    // Some empirically discovered remaining attributes
+    editorElement.removeAttribute('data-medium-editor-element')
+    editorElement.removeAttribute('data-medium-focused')
+    editorElement.classList.remove('medium-editor-element')
+}

--- a/src/local-page/editor.js
+++ b/src/local-page/editor.js
@@ -35,6 +35,8 @@ export default function makeEditable(document) {
     // Return an object that behaves somewhat like MediumEditor's API.
     return {
         subscribe: editor.subscribe.bind(editor),
+        destroy: editor.destroy.bind(editor),
+        setup: editor.setup.bind(editor),
         getContent: () => getContent(document),
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5278,6 +5278,10 @@ mathml-tag-names@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.0.1.tgz#8d41268168bf86d1102b98109e28e531e7a34578"
 
+medium-editor@^5.23.0:
+  version "5.23.1"
+  resolved "https://registry.yarnpkg.com/medium-editor/-/medium-editor-5.23.1.tgz#02e7b6959b8decd9c713d007083e9ef1e2484065"
+
 mem@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"


### PR DESCRIPTION
Basic editing capability for stored pages. Simply overwrites the document, no versioning nor even an indication of having been edited. It builds upon [medium-editor](https://yabwe.github.io/medium-editor/) but currently uses hardly any of its features. It mostly works around the issue that since we want to edit the whole document body, all widgets etcetera introduced by the editor become part of the content. Therefore a hacky `getContent` is implemented that clones the DOM, and removes all those elements and attributes that are part of the editor itself.